### PR TITLE
Fix asmdef references

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/com.jaimecamacho.unityfolders.Editor.asmdef
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/com.jaimecamacho.unityfolders.Editor.asmdef
@@ -1,5 +1,4 @@
 {
   "name": "com.jaimecamacho.unityfolders.Editor",
-  "references": ["com.jaimecamacho.unityfolders.Runtime"],
   "includePlatforms": ["Editor"]
 }


### PR DESCRIPTION
## Summary
- remove unused runtime reference from UnityFolders Editor asmdef

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686451c8a848832682ca449b100793b1