### PR TITLE
Update UnityFolders namespace and asset info

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableArray.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableArray.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Borodar.RainbowFolders.RList {
+namespace UnityFolders.RList {
 
 	[Serializable]
 	public abstract class ReorderableArray<T> : ICloneable, IList<T>, ICollection<T>, IEnumerable<T> {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableAttribute.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableAttribute.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System;
 
-namespace Borodar.RainbowFolders.RList {
+namespace UnityFolders.RList {
 
 	public class ReorderableAttribute : PropertyAttribute {
 

--- a/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableDrawer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableDrawer.cs
@@ -4,7 +4,7 @@ using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace Borodar.RainbowFolders.RList {
+namespace UnityFolders.RList {
 
 	[CustomPropertyDrawer(typeof(ReorderableAttribute))]
 	public class ReorderableDrawer : PropertyDrawer {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableList.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/RList/ReorderableList.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders.RList {
+namespace UnityFolders.RList {
 
 	public class ReorderableList {
 

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ColorHelper.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ColorHelper.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [SuppressMessage("ReSharper", "ConvertIfStatementToNullCoalescingExpression")]
     public static class ColorHelper

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ProjectEditorUtility.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ProjectEditorUtility.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [SuppressMessage("ReSharper", "ConvertIfStatementToNullCoalescingExpression")]
     public static class ProjectEditorUtility

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ProjectWindowAdapter.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/ProjectWindowAdapter.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectWindowAdapter
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/RFLogger.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Helpers/RFLogger.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     internal static class RFLogger
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Info/AssetInfo.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Info/AssetInfo.cs
@@ -1,10 +1,9 @@
-﻿namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     internal static class AssetInfo
     {
-        public const string STORE_ID = "143526";
-        public const string NAME = "Rainbow Folders";
-        public const string VERSION = "2.4.2";
-        public const string HELP_URL = "http://www.borodar.com/stuff/rainbowfolders/docs/quickstart_v" + VERSION + ".pdf";
+        public const string NAME = "UnityFolders";
+        public const string VERSION = "1.0.0";
+        public const string HELP_URL = "https://github.com/JaimeCamachoDev/UnityFolders/blob/main/README.md";
     }
 }

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsBoolean.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsBoolean.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class EditorPrefsBoolean : EditorPrefsItem<bool>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsBooleanRepaint.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsBooleanRepaint.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     internal class EditorPrefsBooleanRepaint : EditorPrefsBoolean
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsItem.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsItem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public abstract class EditorPrefsItem<T>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsModifierKey.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsModifierKey.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class EditorPrefsModifierKey : EditorPrefsItem<EventModifiers> {
 

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsString.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsString.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class EditorPrefsString : EditorPrefsItem<string>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsStringPopup.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/Items/EditorPrefsStringPopup.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class EditorPrefsStringPopup : EditorPrefsItem<string>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/ProjectPreferences.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Prefs/ProjectPreferences.cs
@@ -4,29 +4,29 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectPreferences
     {
         private const float PREF_LABEL_WIDTH = 150f;
 
-        private const string RULESET_PKEY = "Borodar.RainbowFolders.Ruleset.";
+        private const string RULESET_PKEY = "UnityFolders.Ruleset.";
         private const string RULESET_DEFAULT = "Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Data/RainbowFoldersRuleset.asset";
         private const string RULESET_HINT = "The ruleset that is currently used. You could have multiple rulesets in your project and switch between them using this option.";
 
-        private const string EDIT_MODIFIER_PKEY = "Borodar.RainbowFolders.EditMod.";
+        private const string EDIT_MODIFIER_PKEY = "UnityFolders.EditMod.";
         private const string EDIT_MODIFIER_HINT = "Modifier key that is used to show configuration dialogue when clicking on a folder icon.";
         private const EventModifiers EDIT_MODIFIER_DEFAULT = EventModifiers.Alt;
 
-        private const string DRAG_MODIFIER_PKEY = "Borodar.RainbowFolders.DragMod.";
+        private const string DRAG_MODIFIER_PKEY = "UnityFolders.DragMod.";
         private const string DRAG_MODIFIER_HINT = "Modifier key that is used to drag configuration dialogue.";
         private const EventModifiers DRAG_MODIFIER_DEFAULT = EventModifiers.Shift;
         
-        private const string PROJECT_TREE_PKEY = "Borodar.RainbowFolders.ShowProjectTree.";
+        private const string PROJECT_TREE_PKEY = "UnityFolders.ShowProjectTree.";
         private const string PROJECT_TREE_HINT = "Change this setting to show/hide the \"branches\" in the project window.";
         private const bool PROJECT_TREE_DEFAULT = true;
         
-        private const string ROW_SHADING_PKEY = "Borodar.RainbowFolders.RowShading.";
+        private const string ROW_SHADING_PKEY = "UnityFolders.RowShading.";
         private const string ROW_SHADING_HINT = "Change this settings to enable/disable row shading in the project window.";
         private const bool ROW_SHADING_DEFAULT = true;
 
@@ -84,7 +84,7 @@ namespace Borodar.RainbowFolders
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public static SettingsProvider CreateSettingProvider()
         {
-            return new SettingsProvider("Borodar/RainbowFolders", SettingsScope.Project)
+            return new SettingsProvider("UnityFolders", SettingsScope.Project)
             {
                 label = AssetInfo.NAME,
                 guiHandler = OnGUI,

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/RainbowFoldersGUI.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/RainbowFoldersGUI.cs
@@ -4,9 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using static Borodar.RainbowFolders.ProjectWindowAdapter.ViewMode;
+using static UnityFolders.ProjectWindowAdapter.ViewMode;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [InitializeOnLoad]
     public class RainbowFoldersGUI

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRule.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRule.cs
@@ -2,7 +2,7 @@
 using JetBrains.Annotations;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [Serializable]
     public class ProjectRule

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRuleDrawer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRuleDrawer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEditor;
 using UnityEngine;
-using KeyType = Borodar.RainbowFolders.ProjectRule.KeyType;
+using KeyType = UnityFolders.ProjectRule.KeyType;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [CustomPropertyDrawer(typeof(ProjectRule))]
     public class ProjectRuleDrawer : PropertyDrawer

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRuleset.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRuleset.cs
@@ -6,10 +6,10 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Serialization;
-using static Borodar.RainbowFolders.RFLogger;
-using KeyType = Borodar.RainbowFolders.ProjectRule.KeyType;
+using static UnityFolders.RFLogger;
+using KeyType = UnityFolders.ProjectRule.KeyType;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [HelpURL(AssetInfo.HELP_URL)]
 

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetEditor.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetEditor.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Borodar.RainbowFolders.RList;
+using UnityFolders.RList;
 using UnityEditor;
 using UnityEngine;
-using static Borodar.RainbowFolders.ProjectRule.KeyType;
+using static UnityFolders.ProjectRule.KeyType;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     [CustomEditor(typeof (ProjectRuleset))]
     public class ProjectRulesetEditor : Editor

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetExporter.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetExporter.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using static Borodar.RainbowFolders.RFLogger;
+using static UnityFolders.RFLogger;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectRulesetExporter
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetWrapper.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Settings/ProjectRulesetWrapper.cs
@@ -1,4 +1,4 @@
-﻿namespace Borodar.RainbowFolders
+﻿namespace UnityFolders
 {
     internal sealed class ProjectRulesetWrapper
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Backgrounds/ProjectBackground.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Backgrounds/ProjectBackground.cs
@@ -1,4 +1,4 @@
-﻿namespace Borodar.RainbowFolders
+﻿namespace UnityFolders
 {
     public enum ProjectBackground
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Backgrounds/ProjectBackgroundsStorage.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Backgrounds/ProjectBackgroundsStorage.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-using StorageHelper = Borodar.RainbowFolders.TexturesStorageHelper<Borodar.RainbowFolders.ProjectBackground>;
+using StorageHelper = UnityFolders.TexturesStorageHelper<UnityFolders.ProjectBackground>;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectBackgroundsStorage
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/EditorTextures/ProjectEditorTexture.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/EditorTextures/ProjectEditorTexture.cs
@@ -1,4 +1,4 @@
-﻿namespace Borodar.RainbowFolders
+﻿namespace UnityFolders
 {
     public enum ProjectEditorTexture
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/EditorTextures/ProjectEditorTexturesStorage.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/EditorTextures/ProjectEditorTexturesStorage.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
-using StorageHelper = Borodar.RainbowFolders.TexturesStorageHelper<Borodar.RainbowFolders.ProjectEditorTexture>;
+using StorageHelper = UnityFolders.TexturesStorageHelper<UnityFolders.ProjectEditorTexture>;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectEditorTexturesStorage
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIcon.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIcon.cs
@@ -1,4 +1,4 @@
-﻿namespace Borodar.RainbowFolders
+﻿namespace UnityFolders
 {
     public enum ProjectIcon
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconCategory.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconCategory.cs
@@ -1,4 +1,4 @@
-﻿namespace Borodar.RainbowFolders
+﻿namespace UnityFolders
 {
     public enum ProjectIconCategory
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsArchiveFree.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsArchiveFree.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using StorageHelper = Borodar.RainbowFolders.TexturesStorageHelper<Borodar.RainbowFolders.ProjectIcon>;
+using StorageHelper = UnityFolders.TexturesStorageHelper<UnityFolders.ProjectIcon>;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectIconsArchiveFree
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsArchivePro.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsArchivePro.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using StorageHelper = Borodar.RainbowFolders.TexturesStorageHelper<Borodar.RainbowFolders.ProjectIcon>;
+using StorageHelper = UnityFolders.TexturesStorageHelper<UnityFolders.ProjectIcon>;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectIconsArchivePro
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsStorage.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/Icons/ProjectIconsStorage.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
-using StorageHelper = Borodar.RainbowFolders.TexturesStorageHelper<Borodar.RainbowFolders.ProjectIcon>;
+using StorageHelper = UnityFolders.TexturesStorageHelper<UnityFolders.ProjectIcon>;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class ProjectIconsStorage
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/TexturesStorageHelper.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Storage/TexturesStorageHelper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public static class TexturesStorageHelper<T>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/DraggablePopupWindow.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/DraggablePopupWindow.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public abstract class DraggablePopupWindow : EditorWindow
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectBackgroundsPopup.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectBackgroundsPopup.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class ProjectBackgroundsPopup : ProjectSelectionPopup<ProjectBackground>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectIconsPopup.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectIconsPopup.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class ProjectIconsPopup : ProjectSelectionPopup<ProjectIcon>
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectPopupWindow.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectPopupWindow.cs
@@ -2,10 +2,10 @@
 using System.IO;
 using UnityEditor;
 using UnityEngine;
-using static Borodar.RainbowFolders.ColorHelper;
-using KeyType = Borodar.RainbowFolders.ProjectRule.KeyType;
+using static UnityFolders.ColorHelper;
+using KeyType = UnityFolders.ProjectRule.KeyType;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public class ProjectPopupWindow : DraggablePopupWindow
     {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectSelectionPopup.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/Scripts/Windows/ProjectSelectionPopup.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using static Borodar.RainbowFolders.ColorHelper;
+using static UnityFolders.ColorHelper;
 
-namespace Borodar.RainbowFolders
+namespace UnityFolders
 {
     public abstract class ProjectSelectionPopup<T> : DraggablePopupWindow where T : System.Enum
     {


### PR DESCRIPTION
## Summary
- rebrand Rainbow Folders codebase to use `UnityFolders` namespace
- update asset metadata and remove obsolete store link

## Testing
- `npm test --silent --prefix Packages/com.jaimecamacho.unityfolders`

------
https://chatgpt.com/codex/tasks/task_b_6864542982e48326be2d4b343461fcfe