### PR TITLE
Add dynamic preview and overlay fixes

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconRecolorUtility.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconRecolorUtility.cs
@@ -4,11 +4,11 @@ using System.IO;
 
 public static class FolderIconRecolorUtility
 {
-    public static Texture2D RecolorAndSave(Texture2D baseTex, Color tint, string name, Texture2D overlay = null)
+    public static Texture2D Recolor(Texture2D baseTex, Color tint, Texture2D overlay = null)
     {
-        if (!baseTex.isReadable)
+        if (baseTex == null || !baseTex.isReadable)
         {
-            Debug.LogWarning($"Texture '{baseTex.name}' is not readable.");
+            Debug.LogWarning($"Texture '{baseTex?.name}' is not readable.");
             return baseTex;
         }
 
@@ -42,6 +42,13 @@ public static class FolderIconRecolorUtility
         }
 
         newTex.Apply();
+        return newTex;
+    }
+
+    public static Texture2D RecolorAndSave(Texture2D baseTex, Color tint, string name, Texture2D overlay = null)
+    {
+        var newTex = Recolor(baseTex, tint, overlay);
+        if (newTex == null) return baseTex;
 
         byte[] pngData = newTex.EncodeToPNG();
         string path = $"Packages/com.jaimecamacho.unityfolders/Folders/{name}_tint.png";

--- a/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsManager.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsManager.cs
@@ -130,8 +130,8 @@ public static class FolderIconsManager
 
                 GUI.DrawTexture(iconRect, icon, ScaleMode.ScaleToFit, true);
 
-                // 🟡 Dibujo del overlay centrado
-                if (rule.overlayIcon != null)
+                // 🟡 Dibujo del overlay centrado solo en iconos grandes
+                if (rule.overlayIcon != null && isGrid)
                 {
                     float overlaySize = iconRect.width * 0.5f;
                     float overlayX = iconRect.x + (iconRect.width - overlaySize) * 0.5f;

--- a/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsSettingsEditor.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsSettingsEditor.cs
@@ -7,6 +7,23 @@ using JaimeCamachoDev.UnityFolders;
 public class FolderIconsSettingsEditor : Editor
 {
     private ReorderableList list;
+    private readonly Dictionary<Color, Texture2D> gradientCache = new();
+
+    private Texture2D GetGradient(Color baseColor)
+    {
+        if (gradientCache.TryGetValue(baseColor, out var cached))
+            return cached;
+
+        var top = baseColor;
+        var bottom = Color.Lerp(baseColor, Color.black, 0.25f);
+
+        Texture2D tex = new Texture2D(1, 2) { wrapMode = TextureWrapMode.Clamp };
+        tex.SetPixels(new[] { top, bottom });
+        tex.Apply();
+
+        gradientCache[baseColor] = tex;
+        return tex;
+    }
 
     private void OnEnable()
     {
@@ -20,7 +37,7 @@ public class FolderIconsSettingsEditor : Editor
             EditorGUI.LabelField(rect, "Folder Icon Rules");
         };
 
-        list.elementHeightCallback = index => EditorGUIUtility.singleLineHeight * 7 + 36;
+        list.elementHeightCallback = index => EditorGUIUtility.singleLineHeight * 8 + 52;
 
         list.drawElementCallback = (rect, index, isActive, isFocused) =>
         {
@@ -41,12 +58,35 @@ public class FolderIconsSettingsEditor : Editor
             EditorGUI.PropertyField(new Rect(rect.x, y, rect.width, lineHeight), element.FindPropertyRelative("overlayIcon"), new GUIContent("Overlay Icon"));
             y += lineHeight;
 
+            // Previews
+            var settings = (FolderIconsSettings)target;
+            var rule = settings.rules[index];
+            float previewSize = lineHeight * 2.5f;
+            Rect smallRect = new Rect(rect.x, y, previewSize, previewSize);
+            Rect largeRect = new Rect(rect.x + previewSize + 4, y, previewSize, previewSize);
+
+            if (rule.iconSmall != null)
+            {
+                if (rule.background.a > 0.01f)
+                    GUI.DrawTexture(smallRect, GetGradient(rule.background), ScaleMode.StretchToFill);
+                var tex = FolderIconRecolorUtility.Recolor(rule.iconSmall, rule.background);
+                GUI.DrawTexture(smallRect, tex, ScaleMode.ScaleToFit, true);
+            }
+
+            if (rule.iconLarge != null)
+            {
+                if (rule.background.a > 0.01f)
+                    GUI.DrawTexture(largeRect, GetGradient(rule.background), ScaleMode.StretchToFill);
+                var tex = FolderIconRecolorUtility.Recolor(rule.iconLarge, rule.background, rule.overlayIcon);
+                GUI.DrawTexture(largeRect, tex, ScaleMode.ScaleToFit, true);
+            }
+
+            y += previewSize + 4;
+
             if (GUI.Button(new Rect(rect.x, y, rect.width, lineHeight), "Apply Color & Generate Icons"))
             {
-                var settings = (FolderIconsSettings)target;
-                var rule = settings.rules[index];
                 if (rule.iconSmall != null)
-                    rule.iconSmall = FolderIconRecolorUtility.RecolorAndSave(rule.iconSmall, rule.background, rule.match + "_Small", rule.overlayIcon);
+                    rule.iconSmall = FolderIconRecolorUtility.RecolorAndSave(rule.iconSmall, rule.background, rule.match + "_Small");
                 if (rule.iconLarge != null)
                     rule.iconLarge = FolderIconRecolorUtility.RecolorAndSave(rule.iconLarge, rule.background, rule.match + "_Large", rule.overlayIcon);
             }


### PR DESCRIPTION
## Summary
- support in-memory icon recolor for previews
- show icon previews in the settings inspector
- apply overlay only to large icons
- don't generate overlay on small icons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6866aff145bc83268f99ff73a3bcac0c