### PR TITLE
Cache sorted folder icon rules

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsPostprocessor.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsPostprocessor.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using UnityEditor;
+
+class FolderIconsPostprocessor : AssetPostprocessor
+{
+    static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+    {
+        if (importedAssets.Concat(deletedAssets).Concat(movedAssets).Concat(movedFromAssetPaths)
+            .Any(p => p.EndsWith("FolderIconsSettings.asset")))
+        {
+            FolderIconsManager.LoadSettings();
+        }
+    }
+}

--- a/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsSettings.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/FolderIconsSettings.cs
@@ -5,6 +5,13 @@ using UnityEngine;
 public class FolderIconsSettings : ScriptableObject
 {
     public List<FolderIconRule> rules = new();
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        FolderIconsManager.LoadSettings();
+    }
+#endif
 }
 
 [Serializable]


### PR DESCRIPTION
## Summary
- add `sortedRules` cache to `FolderIconsManager`
- recompute cache on settings load or validation
- detect FolderIconsSettings asset changes and reload
- use cached rules in `DrawCustomIcons`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866ba5f6494832686f030a2cb5a0451