### PR TITLE
Add combined folder organize and rename tool

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityAssetsRenamer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityAssetsRenamer.cs
@@ -19,7 +19,7 @@ public static class UnityAssetsRenamer
         RenameAssetsInFolder(folderPath);
     }
 
-    private static void RenameAssetsInFolder(string folderPath)
+    internal static void RenameAssetsInFolder(string folderPath)
     {
         string rootName = Path.GetFileName(folderPath);
         string[] guids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
@@ -37,7 +37,10 @@ public static class UnityAssetsRenamer
             if (nameNoExt.StartsWith(rootName + "_"))
                 continue;
 
-            string newName = rootName + "_" + nameNoExt;
+            int underscoreIndex = nameNoExt.IndexOf('_');
+            string suffix = underscoreIndex >= 0 ? nameNoExt.Substring(underscoreIndex + 1) : nameNoExt;
+
+            string newName = rootName + "_" + suffix;
             string newPath = Path.Combine(directory, newName + extension);
             newPath = AssetDatabase.GenerateUniqueAssetPath(newPath);
             AssetDatabase.MoveAsset(assetPath, newPath);

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityFolderOrganizer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityFolderOrganizer.cs
@@ -16,26 +16,45 @@ public static class UnityFolderOrganizer
             Debug.LogWarning("Por favor selecciona una carpeta válida para ordenar.");
             return;
         }
-        RenameFolderWizard.Show(folderPath);
+        CreateSubfolderWizard.Show(folderPath);
     }
 
-    internal static void OrganizeAndRename(string folderPath, string newFolderName)
+    internal static string OrganizeInChildFolder(string folderPath, string newFolderName)
     {
-        if (!string.IsNullOrWhiteSpace(newFolderName) && newFolderName != Path.GetFileName(folderPath))
+        if (string.IsNullOrWhiteSpace(newFolderName))
         {
-            string parentPath = Path.GetDirectoryName(folderPath);
-            string newPath = Path.Combine(parentPath, newFolderName);
-            newPath = AssetDatabase.GenerateUniqueAssetPath(newPath);
-            string error = AssetDatabase.MoveAsset(folderPath, newPath);
-            if (!string.IsNullOrEmpty(error))
-            {
-                Debug.LogError($"Error al renombrar la carpeta: {error}");
-                return;
-            }
-            folderPath = newPath;
+            Debug.LogWarning("Por favor introduce un nombre válido para la nueva carpeta.");
+            return null;
         }
 
-        OrganizeFolderInternal(folderPath);
+        string uniquePath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(folderPath, newFolderName));
+        string finalName = Path.GetFileName(uniquePath);
+        AssetDatabase.CreateFolder(folderPath, finalName);
+        string newFolderPath = Path.Combine(folderPath, finalName);
+
+        // Mover todos los assets y subcarpetas existentes a la nueva carpeta
+        foreach (string file in Directory.GetFiles(folderPath))
+        {
+            if (file.EndsWith(".meta"))
+                continue;
+
+            string destination = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(newFolderPath, Path.GetFileName(file)));
+            AssetDatabase.MoveAsset(file, destination);
+        }
+
+        foreach (string directory in Directory.GetDirectories(folderPath))
+        {
+            string normalized = directory.Replace("\\", "/");
+            if (normalized == newFolderPath)
+                continue;
+
+            string destination = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(newFolderPath, Path.GetFileName(directory)));
+            AssetDatabase.MoveAsset(normalized, destination);
+        }
+
+        AssetDatabase.Refresh();
+        OrganizeFolderInternal(newFolderPath);
+        return newFolderPath;
     }
 
     private static void OrganizeFolderInternal(string folderPath)
@@ -175,21 +194,20 @@ public static class UnityFolderOrganizer
         }
         return path;
     }
-    private class RenameFolderWizard : ScriptableWizard
+    private class CreateSubfolderWizard : ScriptableWizard
     {
-        public string newFolderName;
+        public string newFolderName = "New Folder";
         private string folderPath;
 
         public static void Show(string folderPath)
         {
-            var wizard = DisplayWizard<RenameFolderWizard>("Renombrar carpeta", "Organizar", "Cancelar");
+            var wizard = DisplayWizard<CreateSubfolderWizard>("Crear subcarpeta", "Organizar", "Cancelar");
             wizard.folderPath = folderPath;
-            wizard.newFolderName = Path.GetFileName(folderPath);
         }
 
         private void OnWizardCreate()
         {
-            UnityFolderOrganizer.OrganizeAndRename(folderPath, newFolderName);
+            UnityFolderOrganizer.OrganizeInChildFolder(folderPath, newFolderName);
         }
     }
 }

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityOrganizeAndRenamer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityOrganizeAndRenamer.cs
@@ -1,0 +1,58 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public static class UnityOrganizeAndRenamer
+{
+    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Ordenar y Renombrar", false, 22)]
+    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Ordenar y Renombrar", false, 22)]
+    private static void OrganizeAndRenameMenu()
+    {
+        string folderPath = GetSelectedPathOrFallback();
+
+        if (!AssetDatabase.IsValidFolder(folderPath))
+        {
+            Debug.LogWarning("Por favor selecciona una carpeta válida para organizar y renombrar.");
+            return;
+        }
+
+        OrganizeAndRenameWizard.Show(folderPath);
+    }
+
+    private static string GetSelectedPathOrFallback()
+    {
+        string path = "Assets";
+
+        foreach (Object obj in Selection.GetFiltered(typeof(Object), SelectionMode.Assets))
+        {
+            path = AssetDatabase.GetAssetPath(obj);
+            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+            {
+                path = Path.GetDirectoryName(path);
+                break;
+            }
+        }
+        return path;
+    }
+
+    private class OrganizeAndRenameWizard : ScriptableWizard
+    {
+        public string newFolderName = "New Folder";
+        private string folderPath;
+
+        public static void Show(string folderPath)
+        {
+            var wizard = DisplayWizard<OrganizeAndRenameWizard>("Ordenar y Renombrar", "Aplicar", "Cancelar");
+            wizard.folderPath = folderPath;
+        }
+
+        private void OnWizardCreate()
+        {
+            string newFolderPath = UnityFolderOrganizer.OrganizeInChildFolder(folderPath, newFolderName);
+            if (!string.IsNullOrEmpty(newFolderPath))
+            {
+                UnityAssetsRenamer.RenameAssetsInFolder(newFolderPath);
+            }
+        }
+    }
+}

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityOrganizeAndRenamer.cs.meta
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityOrganizeAndRenamer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 898984cc15ea4c0e933e8d0de25d897f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Return created subfolder path from folder organizer
- Expose asset renamer for reuse
- Add combined "Ordenar y Renombrar" command to organize into a new subfolder and rename assets

## Testing
- `apt-get update` *(partial failure: Invalid response from proxy 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_b_68c026801d848326a928c45593d4ce0f