### PR TITLE
feat: crear materiales ordenar y renombrar

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityAssetsRenamer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityAssetsRenamer.cs
@@ -34,7 +34,7 @@ public static class UnityAssetsRenamer
             string extension = Path.GetExtension(assetPath);
             string nameNoExt = Path.GetFileNameWithoutExtension(assetPath);
 
-            if (nameNoExt.StartsWith(rootName + "_"))
+            if (nameNoExt == rootName || nameNoExt.StartsWith(rootName + "_"))
                 continue;
 
             int underscoreIndex = nameNoExt.IndexOf('_');

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityFolderOrganizer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityFolderOrganizer.cs
@@ -54,11 +54,11 @@ public static class UnityFolderOrganizer
         }
 
         AssetDatabase.Refresh();
-        OrganizeFolderInternal(newFolderPath);
+        OrganizeFolder(newFolderPath);
         return newFolderPath;
     }
 
-    private static void OrganizeFolderInternal(string folderPath)
+    internal static void OrganizeFolder(string folderPath)
     {
         string[] subfolders = new string[]
         {

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs
@@ -1,0 +1,159 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+using System.Collections.Generic;
+
+public static class UnityMaterialsCreator
+{
+    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Crear Materiales", false, 23)]
+    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Crear Materiales", false, 23)]
+    private static void CreateMaterialsMenu()
+    {
+        string folderPath = GetSelectedPathOrFallback();
+
+        if (!AssetDatabase.IsValidFolder(folderPath))
+        {
+            Debug.LogWarning("Por favor selecciona una carpeta válida para crear materiales.");
+            return;
+        }
+
+        CreateMaterialsInFolder(folderPath);
+    }
+
+    internal static void CreateMaterialsInFolder(string folderPath)
+    {
+        Shader shader = FindShaderByName("VZ_MAS");
+        if (shader == null)
+        {
+            Debug.LogError("No se encontró el shader 'VZ_MAS'.");
+            return;
+        }
+
+        var textureSets = new Dictionary<string, TextureSet>();
+        string[] textureGuids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderPath });
+        foreach (string guid in textureGuids)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guid);
+            string name = Path.GetFileNameWithoutExtension(path);
+            Texture2D tex = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+
+            if (name.EndsWith("_MainText"))
+            {
+                string key = name.Substring(0, name.Length - "_MainText".Length);
+                if (!textureSets.TryGetValue(key, out TextureSet set))
+                    set = textureSets[key] = new TextureSet();
+                set.baseMap = tex;
+            }
+            else if (name.EndsWith("_Normal"))
+            {
+                string key = name.Substring(0, name.Length - "_Normal".Length);
+                if (!textureSets.TryGetValue(key, out TextureSet set))
+                    set = textureSets[key] = new TextureSet();
+                set.bumpMap = tex;
+            }
+            else if (name.EndsWith("_MAS"))
+            {
+                string key = name.Substring(0, name.Length - "_MAS".Length);
+                if (!textureSets.TryGetValue(key, out TextureSet set))
+                    set = textureSets[key] = new TextureSet();
+                set.masMap = tex;
+            }
+        }
+
+        foreach (KeyValuePair<string, TextureSet> kvp in textureSets)
+        {
+            string prefix = kvp.Key;
+            TextureSet set = kvp.Value;
+            string matPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(folderPath, prefix + ".mat"));
+            Material mat = new Material(shader);
+            if (set.baseMap != null)
+                mat.SetTexture("_BaseMap", set.baseMap);
+            if (set.bumpMap != null)
+            {
+                mat.SetTexture("_BumpMap", set.bumpMap);
+                mat.EnableKeyword("_NORMALMAP");
+            }
+            if (set.masMap != null)
+                mat.SetTexture("_MAS", set.masMap);
+            AssetDatabase.CreateAsset(mat, matPath);
+            set.material = mat;
+        }
+
+        string[] modelGuids = AssetDatabase.FindAssets("t:Model", new[] { folderPath });
+        foreach (string guid in modelGuids)
+        {
+            string modelPath = AssetDatabase.GUIDToAssetPath(guid);
+            GameObject model = AssetDatabase.LoadAssetAtPath<GameObject>(modelPath);
+            if (model == null)
+                continue;
+
+            string modelPrefix = model.name;
+            if (modelPrefix.EndsWith("_Geo"))
+                modelPrefix = modelPrefix.Substring(0, modelPrefix.Length - 4);
+
+            Renderer[] renderers = model.GetComponentsInChildren<Renderer>();
+            foreach (Renderer renderer in renderers)
+            {
+                Material[] mats = renderer.sharedMaterials;
+                for (int i = 0; i < mats.Length; i++)
+                {
+                    string matName = mats[i] != null ? mats[i].name : modelPrefix;
+                    if (textureSets.TryGetValue(matName, out TextureSet set) && set.material != null)
+                    {
+                        mats[i] = set.material;
+                    }
+                    else if (textureSets.TryGetValue(modelPrefix, out set) && set.material != null)
+                    {
+                        mats[i] = set.material;
+                    }
+                }
+                renderer.sharedMaterials = mats;
+                EditorUtility.SetDirty(renderer);
+            }
+            EditorUtility.SetDirty(model);
+        }
+
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        Debug.Log($"Materiales creados y asignados en {folderPath}.");
+    }
+
+    private static Shader FindShaderByName(string shaderName)
+    {
+        string[] guids = AssetDatabase.FindAssets(shaderName + " t:Shader");
+        if (guids != null && guids.Length > 0)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guids[0]);
+            return AssetDatabase.LoadAssetAtPath<Shader>(path);
+        }
+        Shader shader = Shader.Find(shaderName);
+        if (shader == null)
+            shader = Shader.Find("Shader Graphs/" + shaderName);
+        return shader;
+    }
+
+    private static string GetSelectedPathOrFallback()
+    {
+        string path = "Assets";
+
+        foreach (Object obj in Selection.GetFiltered(typeof(Object), SelectionMode.Assets))
+        {
+            path = AssetDatabase.GetAssetPath(obj);
+            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+            {
+                path = Path.GetDirectoryName(path);
+                break;
+            }
+        }
+        return path;
+    }
+
+    private class TextureSet
+    {
+        public Texture2D baseMap;
+        public Texture2D bumpMap;
+        public Texture2D masMap;
+        public Material material;
+    }
+}
+

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs.meta
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cc53e5ec5db467288a0c990c729c42c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsOrganizerRenamer.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsOrganizerRenamer.cs
@@ -1,0 +1,41 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public static class UnityMaterialsOrganizerRenamer
+{
+    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Crear Material, Ordenar y Renombrar", false, 24)]
+    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Crear Material, Ordenar y Renombrar", false, 24)]
+    private static void CreateMaterialOrganizeAndRenameMenu()
+    {
+        string folderPath = GetSelectedPathOrFallback();
+
+        if (!AssetDatabase.IsValidFolder(folderPath))
+        {
+            Debug.LogWarning("Por favor selecciona una carpeta válida para crear materiales, organizar y renombrar.");
+            return;
+        }
+
+        UnityMaterialsCreator.CreateMaterialsInFolder(folderPath);
+        UnityFolderOrganizer.OrganizeFolder(folderPath);
+        UnityAssetsRenamer.RenameAssetsInFolder(folderPath);
+
+        Debug.Log($"Materiales creados, carpeta organizada y assets renombrados en {folderPath}.");
+    }
+
+    private static string GetSelectedPathOrFallback()
+    {
+        string path = "Assets";
+
+        foreach (Object obj in Selection.GetFiltered(typeof(Object), SelectionMode.Assets))
+        {
+            path = AssetDatabase.GetAssetPath(obj);
+            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+            {
+                path = Path.GetDirectoryName(path);
+                break;
+            }
+        }
+        return path;
+    }
+}

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsOrganizerRenamer.cs.meta
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsOrganizerRenamer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c2bb0cf0a5e405c8dce7490ecbd8a5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- permitir reutilizar los utilitarios de creación y organización de materiales
- añadir comando unificado para crear materiales, organizar carpetas y renombrar assets
- evitar renombrar assets cuyo nombre ya coincide con la raíz

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c12a2a9e548326a0fcfe7ff5f5887e