### PR TITLE
Add Lit prefab creation workflow

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityMaterialsCreator.cs
@@ -133,6 +133,120 @@ public static class UnityMaterialsCreator
         Debug.Log($"Materiales creados y asignados en {folderPath}.");
     }
 
+    internal static void CreateLitMaterialsInFolder(string folderPath)
+    {
+        Shader shader = FindShaderByName("Universal Render Pipeline/Lit");
+        if (shader == null)
+        {
+            Debug.LogError("No se encontró el shader 'Universal Render Pipeline/Lit'.");
+            return;
+        }
+
+        var textureSets = new Dictionary<string, LitTextureSet>();
+        string[] textureGuids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderPath });
+        foreach (string guid in textureGuids)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guid);
+            string name = Path.GetFileNameWithoutExtension(path);
+            Texture2D tex = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+
+            if (name.EndsWith("_ColorAlpha"))
+            {
+                string key = name.Substring(0, name.Length - "_ColorAlpha".Length);
+                if (!textureSets.TryGetValue(key, out LitTextureSet set))
+                    set = textureSets[key] = new LitTextureSet();
+                set.baseMap = tex;
+            }
+            else if (name.EndsWith("_Normal"))
+            {
+                string key = name.Substring(0, name.Length - "_Normal".Length);
+                if (!textureSets.TryGetValue(key, out LitTextureSet set))
+                    set = textureSets[key] = new LitTextureSet();
+                set.normalMap = tex;
+            }
+            else if (name.EndsWith("_Emission"))
+            {
+                string key = name.Substring(0, name.Length - "_Emission".Length);
+                if (!textureSets.TryGetValue(key, out LitTextureSet set))
+                    set = textureSets[key] = new LitTextureSet();
+                set.emissionMap = tex;
+            }
+            else if (name.EndsWith("_MaskMap") || name.Equals("MaskMap"))
+            {
+                string key = name.EndsWith("_MaskMap") ? name.Substring(0, name.Length - "_MaskMap".Length) : string.Empty;
+                if (!textureSets.TryGetValue(key, out LitTextureSet set))
+                    set = textureSets[key] = new LitTextureSet();
+                set.maskMap = tex;
+            }
+        }
+
+        LitTextureSet unnamedSet = null;
+        foreach (KeyValuePair<string, LitTextureSet> kvp in textureSets)
+        {
+            if (string.IsNullOrEmpty(kvp.Key))
+            {
+                unnamedSet = kvp.Value;
+                continue;
+            }
+
+            CreateLitMaterialAsset(folderPath, kvp.Key, kvp.Value, shader);
+        }
+
+        string[] modelGuids = AssetDatabase.FindAssets("t:Model", new[] { folderPath });
+        foreach (string guid in modelGuids)
+        {
+            string modelPath = AssetDatabase.GUIDToAssetPath(guid);
+            GameObject model = AssetDatabase.LoadAssetAtPath<GameObject>(modelPath);
+            if (model == null)
+                continue;
+
+            string modelPrefix = model.name;
+            if (modelPrefix.EndsWith("_Geo"))
+                modelPrefix = modelPrefix.Substring(0, modelPrefix.Length - 4);
+
+            Renderer[] renderers = model.GetComponentsInChildren<Renderer>();
+            foreach (Renderer renderer in renderers)
+            {
+                Material[] mats = renderer.sharedMaterials;
+                for (int i = 0; i < mats.Length; i++)
+                {
+                    string matName = mats[i] != null ? mats[i].name : modelPrefix;
+                    if (textureSets.TryGetValue(matName, out LitTextureSet set) && set.material != null)
+                    {
+                        mats[i] = set.material;
+                    }
+                    else if (textureSets.TryGetValue(modelPrefix, out set) && set.material != null)
+                    {
+                        mats[i] = set.material;
+                    }
+                    else if (unnamedSet != null)
+                    {
+                        if (!textureSets.TryGetValue(modelPrefix, out set))
+                        {
+                            set = new LitTextureSet
+                            {
+                                baseMap = unnamedSet.baseMap,
+                                normalMap = unnamedSet.normalMap,
+                                emissionMap = unnamedSet.emissionMap,
+                                maskMap = unnamedSet.maskMap
+                            };
+                            CreateLitMaterialAsset(folderPath, modelPrefix, set, shader);
+                            textureSets[modelPrefix] = set;
+                        }
+                        mats[i] = set.material;
+                    }
+                }
+                renderer.sharedMaterials = mats;
+                EditorUtility.SetDirty(renderer);
+            }
+            EditorUtility.SetDirty(model);
+        }
+
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        Debug.Log($"Materiales LIT creados y asignados en {folderPath}.");
+    }
+
     private static Material CreateMaterialAsset(string folderPath, string prefix, TextureSet set, Shader shader)
     {
         if (string.IsNullOrEmpty(prefix))
@@ -155,6 +269,38 @@ public static class UnityMaterialsCreator
         }
         if (set.occlusionMap != null)
             mat.SetTexture("_OcclusionMap", set.occlusionMap);
+        AssetDatabase.CreateAsset(mat, matPath);
+        set.material = mat;
+        return mat;
+    }
+
+    private static Material CreateLitMaterialAsset(string folderPath, string prefix, LitTextureSet set, Shader shader)
+    {
+        if (string.IsNullOrEmpty(prefix))
+            return null;
+
+        string matPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(folderPath, prefix + ".mat"));
+        Material mat = new Material(shader);
+        if (set.baseMap != null)
+            mat.SetTexture("_BaseMap", set.baseMap);
+        if (set.normalMap != null)
+        {
+            mat.SetTexture("_BumpMap", set.normalMap);
+            mat.EnableKeyword("_NORMALMAP");
+        }
+        if (set.maskMap != null)
+        {
+            mat.SetTexture("_MetallicGlossMap", set.maskMap);
+            mat.SetTexture("_OcclusionMap", set.maskMap);
+            mat.EnableKeyword("_METALLICSPECGLOSSMAP");
+            mat.SetFloat("_Metallic", 1f);
+        }
+        if (set.emissionMap != null)
+        {
+            mat.SetTexture("_EmissionMap", set.emissionMap);
+            mat.EnableKeyword("_EMISSION");
+            mat.SetColor("_EmissionColor", Color.white);
+        }
         AssetDatabase.CreateAsset(mat, matPath);
         set.material = mat;
         return mat;
@@ -196,6 +342,15 @@ public static class UnityMaterialsCreator
         public Texture2D normalMap;
         public Texture2D metalSmoothMap;
         public Texture2D occlusionMap;
+        public Material material;
+    }
+
+    private class LitTextureSet
+    {
+        public Texture2D baseMap;
+        public Texture2D normalMap;
+        public Texture2D emissionMap;
+        public Texture2D maskMap;
         public Material material;
     }
 }

--- a/Packages/com.jaimecamacho.unityfolders/Editor/UnityPrefabCreator.cs
+++ b/Packages/com.jaimecamacho.unityfolders/Editor/UnityPrefabCreator.cs
@@ -4,9 +4,9 @@ using System.IO;
 
 public static class UnityPrefabCreator
 {
-    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Crear Prefab", false, 25)]
-    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Crear Prefab", false, 25)]
-    private static void CreatePrefabMenu()
+    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Crear Prefab MAS", false, 25)]
+    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Crear Prefab MAS", false, 25)]
+    private static void CreatePrefabMASMenu()
     {
         string folderPath = GetSelectedPathOrFallback();
 
@@ -16,7 +16,22 @@ public static class UnityPrefabCreator
             return;
         }
 
-        CreatePrefabWizard.Show(folderPath);
+        CreatePrefabWizard.Show(folderPath, PrefabCreationMode.MAS);
+    }
+
+    [MenuItem("Tools/JaimeCamachoDev/UnityFolders/Crear Prefab LIT", false, 26)]
+    [MenuItem("Assets/JaimeCamachoDev/UnityFolders/Crear Prefab LIT", false, 26)]
+    private static void CreatePrefabLITMenu()
+    {
+        string folderPath = GetSelectedPathOrFallback();
+
+        if (!AssetDatabase.IsValidFolder(folderPath))
+        {
+            Debug.LogWarning("Por favor selecciona una carpeta válida para crear el prefab.");
+            return;
+        }
+
+        CreatePrefabWizard.Show(folderPath, PrefabCreationMode.LIT);
     }
 
     internal static void CreatePrefabsInFolder(string folderPath)
@@ -66,21 +81,38 @@ public static class UnityPrefabCreator
         return path;
     }
 
+    private enum PrefabCreationMode
+    {
+        MAS,
+        LIT
+    }
+
     private class CreatePrefabWizard : ScriptableWizard
     {
         public string newFolderName = "New Folder";
         private string folderPath;
+        private PrefabCreationMode mode;
 
-        public static void Show(string folderPath)
+        public static void Show(string folderPath, PrefabCreationMode mode)
         {
+            string title = mode == PrefabCreationMode.MAS ? "Crear Prefab MAS" : "Crear Prefab LIT";
             var wizard = DisplayWizard<CreatePrefabWizard>(
-                "Crear Prefab", "Aplicar", "Cancelar");
+                title, "Aplicar", "Cancelar");
             wizard.folderPath = folderPath;
+            wizard.mode = mode;
         }
 
         private void OnWizardCreate()
         {
-            UnityMaterialsCreator.CreateMaterialsInFolder(folderPath);
+            switch (mode)
+            {
+                case PrefabCreationMode.MAS:
+                    UnityMaterialsCreator.CreateMaterialsInFolder(folderPath);
+                    break;
+                case PrefabCreationMode.LIT:
+                    UnityMaterialsCreator.CreateLitMaterialsInFolder(folderPath);
+                    break;
+            }
 
             string newFolderPath = UnityFolderOrganizer.OrganizeInChildFolder(folderPath, newFolderName);
             if (string.IsNullOrEmpty(newFolderPath))


### PR DESCRIPTION
## Summary
- rename the prefab creation menu entry to "Crear Prefab MAS" and add a new "Crear Prefab LIT" workflow option
- extend the prefab wizard to dispatch to MAS or LIT material creation logic
- implement Lit material creation that maps *_ColorAlpha, *_Normal, *_Emission, and *_MaskMap textures to the URP Lit shader properties

## Testing
- not run (editor scripts)


------
https://chatgpt.com/codex/tasks/task_b_68d4edab813c8326b3d12aafe88c111a