### PR TITLE
Fix npm publish auth: use NPM_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,4 @@ jobs:
         run: npm publish --access public --provenance
         working-directory: ${{ env.PACKAGE_DIR }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The GITHUB_TOKEN is only valid for GitHub services (incl. GitHub Packages), not for registry.npmjs.org. Publishing with it caused npm to return a misleading E404 (npmjs masks 401/403 as 404 on unauthenticated PUT).


Claude-Session: https://claude.ai/code/session_01W8vstogarZqBLrKkc2GuEd