### PR TITLE
Complete Unity package manifest (author, urls, changelog, license)

### DIFF
--- a/Packages/com.jaimecamacho.unityfolders/package.json
+++ b/Packages/com.jaimecamacho.unityfolders/package.json
@@ -1,15 +1,26 @@
 {
-  "author": "Jaime Camacho",
-  "displayName": "UnityFolders",
-  "keywords": [
-    "unity"
-  ],
-  "license": "MIT",
   "name": "com.jaimecamacho.unityfolders",
+  "version": "1.4.0",
+  "displayName": "UnityFolders",
+  "description": "Carpetas personalizadas para Unity",
   "unity": "6000.0",
   "unityRelease": "0f1",
-  "version": "1.4.0",
-  "description": "Carpetas personalizadas para Unity",
+  "license": "MIT",
+  "documentationUrl": "https://github.com/JaimeCamachoDev/UnityFolders",
+  "changelogUrl": "https://github.com/JaimeCamachoDev/UnityFolders/releases",
+  "licensesUrl": "https://github.com/JaimeCamachoDev/UnityFolders/blob/main/LICENSE",
+  "keywords": [
+    "unity",
+    "folders",
+    "editor",
+    "icons",
+    "project structure"
+  ],
+  "author": {
+    "name": "Jaime Camacho",
+    "email": "jaime.camacho.dev@gmail.com",
+    "url": "https://github.com/JaimeCamachoDev"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JaimeCamachoDev/UnityFolders.git"


### PR DESCRIPTION
Rellena el manifest del paquete (`Packages/com.jaimecamacho.unityfolders/package.json`) con los campos estándar de Unity:

- `author` como objeto con `name`, `email` y `url`
- `documentationUrl` → repositorio
- `changelogUrl` → GitHub Releases
- `licensesUrl` → LICENSE del repo
- `keywords` ampliadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8vstogarZqBLrKkc2GuEd)_