### PR TITLE
Auto-detect package folder in publish workflow (fixes rename breakage)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,15 @@ jobs:
 
       - name: Set package path
         run: |
-          repo_name=${GITHUB_REPOSITORY##*/}
-          repo_lower=$(echo "$repo_name" | tr '[:upper:]' '[:lower:]')
-          echo "PACKAGE_DIR=Packages/com.jaimecamacho.$repo_lower" >> $GITHUB_ENV
+          # Auto-detect the embedded UPM package folder (the one under Packages/ that has a package.json).
+          # This survives package renames so the workflow never breaks on a name change.
+          pkg_json=$(find Packages -mindepth 2 -maxdepth 2 -name package.json | head -n1)
+          if [ -z "$pkg_json" ]; then
+            echo "::error::No package.json found under Packages/*/"
+            exit 1
+          fi
+          echo "PACKAGE_DIR=$(dirname "$pkg_json")" >> $GITHUB_ENV
+          echo "Detected package dir: $(dirname "$pkg_json")"
 
       - name: Extract version from tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV


### PR DESCRIPTION
El workflow tenía el prefijo `com.jaimecamacho.` escrito a mano. Tras renombrar el paquete a `com.jaimecamachodev.unityfolders`, la carpeta calculada dejó de existir y la publicación falló:

```
jq: error: Could not open file Packages/com.jaimecamacho.unityfolders/package.json: No such file or directory
```

Ahora el paso **detecta automáticamente** la carpeta del paquete (`Packages/*/package.json`), así el workflow no se rompe aunque cambie el nombre del paquete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8vstogarZqBLrKkc2GuEd)_