### PR TITLE
Fix npm publish resolving the tarball path as a git shorthand

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,9 +77,10 @@ jobs:
       - name: Verify the Unity signature is present
         run: |
           tgz=$(ls out/*.tgz | head -n1)
-          if tar -tzf "$tgz" | grep -q 'package/.attestation.p7m'; then
+          if tar -tzf "$tgz" 2>/dev/null | grep -q 'package/.attestation.p7m'; then
             echo "Signed OK: $tgz"
-            echo "TGZ=$tgz" >> "$GITHUB_ENV"
+            # Absolute path so npm treats it as a local tarball (not a github user/repo shorthand).
+            echo "TGZ=$(pwd)/$tgz" >> "$GITHUB_ENV"
           else
             echo "::error::Packing produced no .attestation.p7m — signing did not happen. Check the service account secrets/role."
             exit 1


### PR DESCRIPTION
El empaquetado y la firma funcionan (`Signed OK`). El fallo estaba solo en el `npm publish`: npm interpretaba `out/foo.tgz` como un repo de GitHub (`owner/repo`) e intentaba clonarlo por SSH → `Permission denied (publickey)`.

Se pasa ahora una **ruta absoluta** al tarball para que npm lo trate como archivo local. También se silencia el ruido de `tar` (SIGPIPE) en el paso de verificación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8vstogarZqBLrKkc2GuEd)_