### PR TITLE
Add VzFolders installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ Esta es la estructura oficial del proyecto, diseñada para maximizar claridad, e
 
 ---
 
+## 📦 Instalación (VzFolders vía Package Manager)
+
+Esta tool (`VzFolders`) se distribuye como paquete de Unity Package Manager con el id `com.jaimecamachodev.unityfolders`, publicado en npm.
+
+Para instalarla en **otro proyecto de Unity**, añade un scoped registry a tu `Packages/manifest.json`:
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "JaimeCamachoDevs",
+      "url": "https://registry.npmjs.org",
+      "scopes": [
+        "com.jaimecamachodev"
+      ]
+    }
+  ],
+  "dependencies": {
+    "com.jaimecamachodev.unityfolders": "1.8.2"
+  }
+}
+```
+
+También puedes hacerlo desde el Editor:
+1. `Edit > Project Settings > Package Manager`.
+2. En **Scoped Registries**, pulsa `+` y añade:
+   - **Name:** `JaimeCamachoDevs`
+   - **URL:** `https://registry.npmjs.org`
+   - **Scope(s):** `com.jaimecamachodev`
+3. Abre `Window > Package Manager`, cambia el desplegable a **My Registries** y busca **UnityFolders** para instalarla.
+
+---
+
 ## 📂 Estructura Principal
 
 ```


### PR DESCRIPTION
## Summary
Added comprehensive installation documentation for the VzFolders package manager tool to the project README.

## Changes
- Added new "📦 Instalación (VzFolders vía Package Manager)" section to README.md
- Documented how to install VzFolders in other Unity projects via UPM (Unity Package Manager)
- Provided two installation methods:
  - Manual configuration of `Packages/manifest.json` with scoped registry details
  - Step-by-step UI instructions through the Unity Editor (Edit > Project Settings > Package Manager)
- Included the package identifier (`com.jaimecamachodev.unityfolders`) and current version (`1.8.2`)
- Specified the npm registry URL for package distribution

## Details
The documentation explains that VzFolders is distributed as a UPM package and provides clear instructions for developers who want to use this tool in their own Unity projects. Both manual and GUI-based installation approaches are covered to accommodate different user preferences.

https://claude.ai/code/session_018zFx38sd9jsi8HLejYKwC3