### PR TITLE
Add VzFolders asset-organization pipeline (project structure, type fo…

### DIFF
--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0a21d514e544757bba73a912912c6f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetTypeFolders.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetTypeFolders.cs
@@ -1,0 +1,98 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+
+namespace VzFolders.Pipeline
+{
+    // Shared taxonomy used both when creating per-type asset folders and when
+    // auto-organizing a chaotic folder, so the two features never drift apart.
+    static class VzFoldersAssetTypeFolders
+    {
+        public const string Animation = "Animation";
+        public const string Audio = "Audio";
+        public const string Material = "Material";
+        public const string Mesh = "Mesh";
+        public const string Prefab = "Prefab";
+        public const string Script = "Script";
+        public const string Shader = "Shader";
+        public const string VFX = "VFX";
+
+        public static readonly string[] All = { Animation, Audio, Material, Mesh, Prefab, Script, Shader, VFX };
+
+        // Returns the type folder an asset belongs to, or null if it should be left where it is.
+        public static string GetFolderForAsset(string assetPath)
+        {
+            switch (assetPath.GetExtensionLower())
+            {
+                case ".anim":
+                case ".controller":
+                case ".overridecontroller":
+                    return Animation;
+
+                case ".fbx":
+                case ".dae":
+                case ".obj":
+                case ".blend":
+                    return HasAnimationClips(assetPath) ? Animation : Mesh;
+
+                case ".wav":
+                case ".mp3":
+                case ".ogg":
+                case ".aiff":
+                    return Audio;
+
+                case ".mat":
+                case ".png":
+                case ".jpg":
+                case ".jpeg":
+                case ".tga":
+                case ".tif":
+                case ".tiff":
+                case ".psd":
+                case ".bmp":
+                case ".gif":
+                case ".exr":
+                case ".hdr":
+                    return Material;
+
+                case ".mesh":
+                    return Mesh;
+
+                case ".prefab":
+                    return Prefab;
+
+                case ".cs":
+                case ".js":
+                case ".boo":
+                    return Script;
+
+                case ".shader":
+                case ".cginc":
+                case ".shadergraph":
+                case ".shadersubgraph":
+                case ".compute":
+                case ".hlsl":
+                    return Shader;
+
+                case ".vfx":
+                case ".vfxgraph":
+                    return VFX;
+
+                default:
+                    return null;
+            }
+        }
+
+        static bool HasAnimationClips(string assetPath)
+        {
+            var importer = AssetImporter.GetAtPath(assetPath) as ModelImporter;
+            if (importer == null) return false;
+
+            return (importer.clipAnimations != null && importer.clipAnimations.Length > 0)
+                || (importer.defaultClipAnimations != null && importer.defaultClipAnimations.Length > 0);
+        }
+
+        static string GetExtensionLower(this string path) => Path.GetExtension(path).ToLowerInvariant();
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetTypeFolders.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetTypeFolders.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ab030b7f38f244cf8a0479ea79ce7fe0

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs
@@ -1,0 +1,66 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using static VzFolders.Libs.VUtils;
+
+namespace VzFolders.Pipeline
+{
+    // Prefixes every asset directly or indirectly inside a folder with that folder's name,
+    // e.g. dropping Diffuse.png/Normal.png into "Rock01" renames them Rock01_Diffuse/Rock01_Normal.
+    static class VzFoldersAssetsRenamer
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+
+        [MenuItem(dir + "Organize/Rename assets with folder prefix", false, 222)]
+        [MenuItem(assetsDir + "Rename assets with folder prefix", false, 222)]
+        static void RenameAssetsMenu()
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida para renombrar sus assets.");
+                return;
+            }
+
+            RenameAssetsInFolder(folderPath);
+        }
+
+        internal static void RenameAssetsInFolder(string folderPath)
+        {
+            var rootName = folderPath.GetFilename(withExtension: true);
+            var guids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
+
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+
+                foreach (var guid in guids)
+                {
+                    var assetPath = guid.ToPath();
+                    if (AssetDatabase.IsValidFolder(assetPath)) continue;
+
+                    var directory = assetPath.GetParentPath();
+                    var extension = assetPath.GetExtension();
+                    var nameNoExt = assetPath.GetFilename(withExtension: false);
+
+                    if (nameNoExt == rootName || nameNoExt.StartsWith(rootName + "_")) continue;
+
+                    var underscoreIndex = nameNoExt.IndexOf('_');
+                    var suffix = underscoreIndex >= 0 ? nameNoExt.Substring(underscoreIndex + 1) : nameNoExt;
+
+                    var newPath = AssetDatabase.GenerateUniqueAssetPath(directory.CombinePath(rootName + "_" + suffix + extension));
+                    AssetDatabase.MoveAsset(assetPath, newPath);
+                }
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+
+            AssetDatabase.Refresh();
+            Debug.Log($"VzFolders: assets renombrados en {folderPath}.");
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b903024ce2594a41ad12cbda10eb1557

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersIngestWizard.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersIngestWizard.cs
@@ -1,0 +1,79 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+namespace VzFolders.Pipeline
+{
+    // One configurable wizard covering the full raw-asset-dump ingest flow so the
+    // "create materials -> wrap in folder -> rename -> create prefabs" steps aren't
+    // duplicated across several near-identical menu commands.
+    static class VzFoldersIngestWizard
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+
+        enum MaterialMode { None, Mas, Lit }
+
+        [MenuItem(dir + "Ingest pipeline/Full pipeline...", false, 243)]
+        [MenuItem(assetsDir + "Full ingest pipeline...", false, 243)]
+        static void ShowWizard()
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida.");
+                return;
+            }
+
+            IngestWizard.Show(folderPath);
+        }
+
+        class IngestWizard : ScriptableWizard
+        {
+            public MaterialMode createMaterials = MaterialMode.None;
+            public bool wrapInNewSubfolder = true;
+            public string newSubfolderName = "New Folder";
+            public bool renameAssetsWithPrefix = true;
+            public bool createPrefabsFromMeshes = false;
+
+            string folderPath;
+
+            public static void Show(string folderPath)
+            {
+                var wizard = DisplayWizard<IngestWizard>("VzFolders — Full ingest pipeline", "Run", "Cancel");
+                wizard.folderPath = folderPath;
+            }
+
+            void OnWizardCreate()
+            {
+                var workingFolder = folderPath;
+
+                switch (createMaterials)
+                {
+                    case MaterialMode.Mas: VzFoldersMaterialsCreator.CreateMasMaterialsInFolder(workingFolder); break;
+                    case MaterialMode.Lit: VzFoldersMaterialsCreator.CreateLitMaterialsInFolder(workingFolder); break;
+                }
+
+                if (wrapInNewSubfolder)
+                {
+                    var newFolder = VzFoldersOrganizer.OrganizeIntoNewSubfolder(workingFolder, newSubfolderName);
+                    if (string.IsNullOrEmpty(newFolder)) return;
+                    workingFolder = newFolder;
+                }
+                else
+                {
+                    VzFoldersOrganizer.OrganizeFolder(workingFolder);
+                }
+
+                if (renameAssetsWithPrefix)
+                    VzFoldersAssetsRenamer.RenameAssetsInFolder(workingFolder);
+
+                if (createPrefabsFromMeshes)
+                    VzFoldersPrefabCreator.CreatePrefabsInFolder(workingFolder);
+
+                Debug.Log($"VzFolders: pipeline de ingesta completado en {workingFolder}.");
+            }
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersIngestWizard.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersIngestWizard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1753e96af549442abdfc9a32bd094c72

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs
@@ -1,0 +1,239 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using static VzFolders.Libs.VUtils;
+
+namespace VzFolders.Pipeline
+{
+    // Builds URP materials from a folder of loose textures following a suffix naming convention,
+    // then assigns them to the imported models sitting in the same folder.
+    static class VzFoldersMaterialsCreator
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+        const string urpLitShaderName = "Universal Render Pipeline/Lit";
+
+        [MenuItem(dir + "Ingest pipeline/Create materials (MAS: Color, Normal, MetalSmooth, AO)", false, 240)]
+        [MenuItem(assetsDir + "Create materials (MAS)", false, 240)]
+        static void CreateMasMaterialsMenu() => RunOnSelectedFolder(CreateMasMaterialsInFolder);
+
+        [MenuItem(dir + "Ingest pipeline/Create materials (Lit: Color, Normal, Emission, MaskMap)", false, 241)]
+        [MenuItem(assetsDir + "Create materials (Lit)", false, 241)]
+        static void CreateLitMaterialsMenu() => RunOnSelectedFolder(CreateLitMaterialsInFolder);
+
+        static void RunOnSelectedFolder(System.Action<string> action)
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida para crear materiales.");
+                return;
+            }
+
+            action(folderPath);
+        }
+
+        // "MAS" (Metallic-AO-Smoothness) style texture set: _ColorAlpha, _Normal, _MetalSmooth, _AO.
+        internal static void CreateMasMaterialsInFolder(string folderPath)
+        {
+            var shader = FindUrpLitShader();
+            if (shader == null) return;
+
+            var suffixes = new (string suffix, System.Action<TextureSet, Texture2D> assign)[]
+            {
+                ("_ColorAlpha", (set, tex) => set.baseMap = tex),
+                ("_Normal", (set, tex) => set.normalMap = tex),
+                ("_MetalSmooth", (set, tex) => set.metalSmoothMap = tex),
+                ("_AO", (set, tex) => set.occlusionMap = tex),
+            };
+
+            var textureSets = BuildTextureSets(folderPath, suffixes);
+            CreateMaterialAssets(folderPath, textureSets, shader, CreateMasMaterialAsset);
+            AssignMaterialsToModels(folderPath, textureSets, shader, CreateMasMaterialAsset);
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            Debug.Log($"VzFolders: materiales MAS creados y asignados en {folderPath}.");
+        }
+
+        // URP Lit style texture set: _ColorAlpha, _Normal, _Emission, _MaskMap.
+        internal static void CreateLitMaterialsInFolder(string folderPath)
+        {
+            var shader = FindUrpLitShader();
+            if (shader == null) return;
+
+            var suffixes = new (string suffix, System.Action<TextureSet, Texture2D> assign)[]
+            {
+                ("_ColorAlpha", (set, tex) => set.baseMap = tex),
+                ("_Normal", (set, tex) => set.normalMap = tex),
+                ("_Emission", (set, tex) => set.emissionMap = tex),
+                ("_MaskMap", (set, tex) => set.maskMap = tex),
+            };
+
+            var textureSets = BuildTextureSets(folderPath, suffixes);
+            CreateMaterialAssets(folderPath, textureSets, shader, CreateLitMaterialAsset);
+            AssignMaterialsToModels(folderPath, textureSets, shader, CreateLitMaterialAsset);
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            Debug.Log($"VzFolders: materiales Lit creados y asignados en {folderPath}.");
+        }
+
+        static Dictionary<string, TextureSet> BuildTextureSets(string folderPath, (string suffix, System.Action<TextureSet, Texture2D> assign)[] suffixes)
+        {
+            var textureSets = new Dictionary<string, TextureSet>();
+
+            foreach (var guid in AssetDatabase.FindAssets("t:Texture2D", new[] { folderPath }))
+            {
+                var path = guid.ToPath();
+                var name = path.GetFilename(withExtension: false);
+                var tex = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+
+                foreach (var (suffix, assign) in suffixes)
+                {
+                    if (!name.EndsWith(suffix) && name != suffix.TrimStart('_')) continue;
+
+                    var key = name.EndsWith(suffix) ? name.Substring(0, name.Length - suffix.Length) : "";
+                    if (!textureSets.TryGetValue(key, out var set))
+                        set = textureSets[key] = new TextureSet();
+
+                    assign(set, tex);
+                    break;
+                }
+            }
+
+            return textureSets;
+        }
+
+        static void CreateMaterialAssets(string folderPath, Dictionary<string, TextureSet> textureSets, Shader shader, System.Func<string, TextureSet, Shader, Material> createAsset)
+        {
+            foreach (var kvp in textureSets)
+            {
+                if (string.IsNullOrEmpty(kvp.Key)) continue; // the unnamed/default set is only used as a fallback for models below
+                createAsset(kvp.Key.CombinePathFolder(folderPath), kvp.Value, shader);
+            }
+        }
+
+        static void AssignMaterialsToModels(string folderPath, Dictionary<string, TextureSet> textureSets, Shader shader, System.Func<string, TextureSet, Shader, Material> createAsset)
+        {
+            textureSets.TryGetValue("", out var unnamedSet);
+
+            foreach (var guid in AssetDatabase.FindAssets("t:Model", new[] { folderPath }))
+            {
+                var modelPath = guid.ToPath();
+                var model = AssetDatabase.LoadAssetAtPath<GameObject>(modelPath);
+                if (model == null) continue;
+
+                var modelPrefix = model.name.EndsWith("_Geo") ? model.name.Substring(0, model.name.Length - 4) : model.name;
+
+                foreach (var renderer in model.GetComponentsInChildren<Renderer>())
+                {
+                    var mats = renderer.sharedMaterials;
+                    for (var i = 0; i < mats.Length; i++)
+                    {
+                        var matName = mats[i] != null ? mats[i].name : modelPrefix;
+
+                        if (textureSets.TryGetValue(matName, out var set) && set.material != null)
+                        {
+                            mats[i] = set.material;
+                        }
+                        else if (textureSets.TryGetValue(modelPrefix, out set) && set.material != null)
+                        {
+                            mats[i] = set.material;
+                        }
+                        else if (unnamedSet != null)
+                        {
+                            if (!textureSets.TryGetValue(modelPrefix, out set))
+                            {
+                                set = new TextureSet
+                                {
+                                    baseMap = unnamedSet.baseMap,
+                                    normalMap = unnamedSet.normalMap,
+                                    metalSmoothMap = unnamedSet.metalSmoothMap,
+                                    occlusionMap = unnamedSet.occlusionMap,
+                                    emissionMap = unnamedSet.emissionMap,
+                                    maskMap = unnamedSet.maskMap,
+                                };
+                                createAsset(modelPrefix.CombinePathFolder(folderPath), set, shader);
+                                textureSets[modelPrefix] = set;
+                            }
+                            mats[i] = set.material;
+                        }
+                    }
+                    renderer.sharedMaterials = mats;
+                    EditorUtility.SetDirty(renderer);
+                }
+                EditorUtility.SetDirty(model);
+            }
+        }
+
+        static Material CreateMasMaterialAsset(string matPath, TextureSet set, Shader shader)
+        {
+            if (string.IsNullOrEmpty(matPath)) return null;
+
+            var mat = new Material(shader);
+            if (set.baseMap != null) mat.SetTexture("_BaseMap", set.baseMap);
+            if (set.normalMap != null) { mat.SetTexture("_BumpMap", set.normalMap); mat.EnableKeyword("_NORMALMAP"); }
+            if (set.metalSmoothMap != null) { mat.SetTexture("_MetallicGlossMap", set.metalSmoothMap); mat.EnableKeyword("_METALLICSPECGLOSSMAP"); mat.SetFloat("_Metallic", 1f); }
+            if (set.occlusionMap != null) mat.SetTexture("_OcclusionMap", set.occlusionMap);
+
+            AssetDatabase.CreateAsset(mat, matPath);
+            set.material = mat;
+            return mat;
+        }
+
+        static Material CreateLitMaterialAsset(string matPath, TextureSet set, Shader shader)
+        {
+            if (string.IsNullOrEmpty(matPath)) return null;
+
+            var mat = new Material(shader);
+            if (set.baseMap != null) mat.SetTexture("_BaseMap", set.baseMap);
+            if (set.normalMap != null) { mat.SetTexture("_BumpMap", set.normalMap); mat.EnableKeyword("_NORMALMAP"); }
+            if (set.maskMap != null)
+            {
+                mat.SetTexture("_MaskMap", set.maskMap);
+                mat.SetTexture("_MetallicGlossMap", set.maskMap);
+                mat.SetTexture("_OcclusionMap", set.maskMap);
+                mat.EnableKeyword("_METALLICSPECGLOSSMAP");
+                mat.SetFloat("_Metallic", 1f);
+                mat.SetFloat("_OcclusionStrength", 1f);
+            }
+            if (set.emissionMap != null)
+            {
+                mat.SetTexture("_EmissionMap", set.emissionMap);
+                mat.EnableKeyword("_EMISSION");
+                mat.SetColor("_EmissionColor", Color.white);
+            }
+
+            AssetDatabase.CreateAsset(mat, matPath);
+            set.material = mat;
+            return mat;
+        }
+
+        static Shader FindUrpLitShader()
+        {
+            var guids = AssetDatabase.FindAssets(urpLitShaderName + " t:Shader");
+            var shader = guids.Length > 0 ? AssetDatabase.LoadAssetAtPath<Shader>(guids[0].ToPath()) : null;
+            shader = shader != null ? shader : Shader.Find(urpLitShaderName);
+
+            if (shader == null) Debug.LogError($"VzFolders: no se encontró el shader '{urpLitShaderName}'.");
+            return shader;
+        }
+
+        static string CombinePathFolder(this string materialName, string folderPath) =>
+            AssetDatabase.GenerateUniqueAssetPath(folderPath.CombinePath(materialName + ".mat"));
+
+        class TextureSet
+        {
+            public Texture2D baseMap;
+            public Texture2D normalMap;
+            public Texture2D metalSmoothMap;
+            public Texture2D occlusionMap;
+            public Texture2D emissionMap;
+            public Texture2D maskMap;
+            public Material material;
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a69f6587263444688fcf4e6a488b8008

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs
@@ -1,0 +1,137 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using static VzFolders.Libs.VUtils;
+
+namespace VzFolders.Pipeline
+{
+    // Sorts a folder where artists dropped materials/meshes/textures/etc. all mixed together
+    // into the shared Animation/Audio/Material/Mesh/Prefab/Script/Shader/VFX taxonomy.
+    static class VzFoldersOrganizer
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+
+        [MenuItem(dir + "Organize/Organize this folder", false, 220)]
+        [MenuItem(assetsDir + "Organize this folder", false, 220)]
+        static void OrganizeSelectedFolder()
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida para ordenar.");
+                return;
+            }
+
+            OrganizeFolder(folderPath);
+        }
+
+        [MenuItem(dir + "Organize/Organize into new subfolder...", false, 221)]
+        [MenuItem(assetsDir + "Organize into new subfolder...", false, 221)]
+        static void OrganizeIntoNewSubfolderMenu()
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida para ordenar.");
+                return;
+            }
+
+            NewSubfolderWizard.Show(folderPath);
+        }
+
+        // Wraps everything currently inside folderPath into a new subfolder named newFolderName, then organizes it.
+        // Returns the new subfolder's path, or null if the name was invalid.
+        internal static string OrganizeIntoNewSubfolder(string folderPath, string newFolderName)
+        {
+            if (string.IsNullOrWhiteSpace(newFolderName))
+            {
+                Debug.LogWarning("VzFolders: introduce un nombre válido para la nueva carpeta.");
+                return null;
+            }
+
+            var newFolderPath = AssetDatabase.GenerateUniqueAssetPath(folderPath.CombinePath(newFolderName));
+            AssetDatabase.CreateFolder(folderPath, newFolderPath.GetFilename(withExtension: true));
+
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+
+                foreach (var file in Directory.GetFiles(folderPath))
+                {
+                    if (file.EndsWith(".meta")) continue;
+                    var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(file)));
+                    AssetDatabase.MoveAsset(file.Replace("\\", "/"), destination);
+                }
+
+                foreach (var directory in Directory.GetDirectories(folderPath))
+                {
+                    var normalized = directory.Replace("\\", "/");
+                    if (normalized == newFolderPath) continue;
+
+                    var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(directory)));
+                    AssetDatabase.MoveAsset(normalized, destination);
+                }
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+
+            AssetDatabase.Refresh();
+            OrganizeFolder(newFolderPath);
+            return newFolderPath;
+        }
+
+        // Moves every loose asset directly inside folderPath into its type subfolder (created on demand),
+        // then deletes any subfolder left empty by the move.
+        internal static void OrganizeFolder(string folderPath)
+        {
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+
+                var assetGuids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
+                foreach (var guid in assetGuids)
+                {
+                    var assetPath = guid.ToPath();
+                    if (AssetDatabase.IsValidFolder(assetPath)) continue;
+
+                    var destinationFolderName = VzFoldersAssetTypeFolders.GetFolderForAsset(assetPath);
+                    if (destinationFolderName == null) continue;
+
+                    var destinationFolder = folderPath.CombinePath(destinationFolderName);
+                    if (!AssetDatabase.IsValidFolder(destinationFolder))
+                        AssetDatabase.CreateFolder(folderPath, destinationFolderName);
+
+                    var destinationPath = AssetDatabase.GenerateUniqueAssetPath(destinationFolder.CombinePath(assetPath.GetFilename(withExtension: true)));
+                    AssetDatabase.MoveAsset(assetPath, destinationPath);
+                }
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+
+            VzFoldersPipelineUtils.RemoveEmptySubdirectories(folderPath);
+            AssetDatabase.Refresh();
+            Debug.Log($"VzFolders: carpeta {folderPath} ordenada.");
+        }
+
+        class NewSubfolderWizard : ScriptableWizard
+        {
+            public string newFolderName = "New Folder";
+            string folderPath;
+
+            public static void Show(string folderPath)
+            {
+                var wizard = DisplayWizard<NewSubfolderWizard>("Organize into new subfolder", "Organize", "Cancel");
+                wizard.folderPath = folderPath;
+            }
+
+            void OnWizardCreate() => OrganizeIntoNewSubfolder(folderPath, newFolderName);
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74b8debc39f34afea6caab80b1be9a0b

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPipelineUtils.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPipelineUtils.cs
@@ -1,0 +1,36 @@
+#if UNITY_EDITOR
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using Object = UnityEngine.Object;
+
+namespace VzFolders.Pipeline
+{
+    static class VzFoldersPipelineUtils
+    {
+        // The folder the current Project window selection points at, or "Assets" if nothing/no folder is selected.
+        public static string GetSelectedFolderOrFallback()
+        {
+            foreach (var obj in Selection.GetFiltered(typeof(Object), SelectionMode.Assets))
+            {
+                var path = AssetDatabase.GetAssetPath(obj);
+                if (string.IsNullOrEmpty(path)) continue;
+
+                return AssetDatabase.IsValidFolder(path) ? path : Path.GetDirectoryName(path).Replace("\\", "/");
+            }
+
+            return "Assets";
+        }
+
+        public static void RemoveEmptySubdirectories(string rootPath)
+        {
+            var directories = Directory.GetDirectories(rootPath, "*", SearchOption.AllDirectories)
+                                        .OrderByDescending(d => d.Length);
+
+            foreach (var directory in directories)
+                if (Directory.GetFileSystemEntries(directory).Length == 0)
+                    AssetDatabase.DeleteAsset(directory.Replace("\\", "/"));
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPipelineUtils.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPipelineUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a78f71e5e58242f3bf1ec865679a46e3

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs
@@ -1,0 +1,63 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using static VzFolders.Libs.VUtils;
+
+namespace VzFolders.Pipeline
+{
+    // Instantiates every model found in <folder>/Mesh and saves it as a prefab in <folder>/Prefab.
+    static class VzFoldersPrefabCreator
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+
+        [MenuItem(dir + "Ingest pipeline/Create prefabs from Mesh folder", false, 242)]
+        [MenuItem(assetsDir + "Create prefabs from Mesh folder", false, 242)]
+        static void CreatePrefabsMenu()
+        {
+            var folderPath = VzFoldersPipelineUtils.GetSelectedFolderOrFallback();
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                Debug.LogWarning("VzFolders: selecciona una carpeta válida para crear prefabs.");
+                return;
+            }
+
+            CreatePrefabsInFolder(folderPath);
+        }
+
+        internal static void CreatePrefabsInFolder(string folderPath)
+        {
+            var meshFolder = folderPath.CombinePath(VzFoldersAssetTypeFolders.Mesh);
+            var prefabFolder = folderPath.CombinePath(VzFoldersAssetTypeFolders.Prefab);
+
+            if (!AssetDatabase.IsValidFolder(meshFolder))
+            {
+                Debug.LogWarning($"VzFolders: no existe la carpeta {meshFolder}, nada que convertir a prefab.");
+                return;
+            }
+
+            if (!AssetDatabase.IsValidFolder(prefabFolder))
+                AssetDatabase.CreateFolder(folderPath, VzFoldersAssetTypeFolders.Prefab);
+
+            foreach (var guid in AssetDatabase.FindAssets("t:Model", new[] { meshFolder }))
+            {
+                var modelPath = guid.ToPath();
+                var model = AssetDatabase.LoadAssetAtPath<GameObject>(modelPath);
+                if (model == null) continue;
+
+                var prefix = model.name.EndsWith("_Geo") ? model.name.Substring(0, model.name.Length - 4) : model.name;
+                var prefabPath = AssetDatabase.GenerateUniqueAssetPath(prefabFolder.CombinePath(prefix + ".prefab"));
+
+                var instance = PrefabUtility.InstantiatePrefab(model) as GameObject;
+                instance.name = prefix;
+                PrefabUtility.SaveAsPrefabAsset(instance, prefabPath);
+                Object.DestroyImmediate(instance);
+            }
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            Debug.Log($"VzFolders: prefabs creados en {prefabFolder}.");
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a018b28ab8f4be9a94feecccb6573bc

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersProjectStructure.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersProjectStructure.cs
@@ -1,0 +1,96 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using static VzFolders.Libs.VUtils;
+
+namespace VzFolders.Pipeline
+{
+    static class VzFoldersProjectStructure
+    {
+        const string dir = "Tools/JaimeCamachoDev/VzFolders/";
+        const string assetsDir = "Assets/VzFolders/";
+
+        [MenuItem(dir + "Project structure/Create base project structure", false, 200)]
+        [MenuItem(assetsDir + "Create base project structure", false, 200)]
+        static void CreateBaseProjectStructure()
+        {
+            CreateFolder("Assets", "1-Programming");
+            CreateFolder("Assets/1-Programming", "Observers");
+            CreateFolder("Assets/1-Programming", "Prefabs");
+            CreateFolder("Assets/1-Programming", "Scripts");
+            CreateFolder("Assets/1-Programming", "SolidMats");
+
+            CreateFolder("Assets", "2-Art");
+            CreateFolder("Assets/2-Art", "1-3D");
+            CreateFolder("Assets/2-Art/1-3D", "Animals");
+            CreateFolder("Assets/2-Art/1-3D", "Characters");
+            CreateFolder("Assets/2-Art/1-3D", "Environments");
+            CreateFolder("Assets/2-Art", "2-VFX");
+            CreateFolder("Assets/2-Art", "3-SFX");
+            CreateFolder("Assets/2-Art", "4-Directors");
+            CreateFolder("Assets/2-Art", "5-Skyboxes");
+            CreateFolder("Assets/2-Art", "6-Videos");
+            CreateFolder("Assets/2-Art", "7-PostProcessing");
+            CreateFolder("Assets/2-Art", "8-UI");
+
+            CreateFolder("Assets", "3-Scenes");
+            CreateFolder("Assets", "4-Presets");
+            CreateFolder("Assets", "5-Settings");
+
+            AssetDatabase.Refresh();
+            Debug.Log("VzFolders: estructura base del proyecto creada.");
+        }
+
+        [MenuItem(dir + "Project structure/Create asset type folders...", false, 201)]
+        [MenuItem(assetsDir + "Create asset type folders...", false, 201)]
+        static void CreateAssetTypeFoldersMenu()
+        {
+            NewTypedFolderWizard.Show(VzFoldersPipelineUtils.GetSelectedFolderOrFallback());
+        }
+
+        // Creates <parentPath>/<name>/{Animation,Audio,Material,Mesh,Prefab,Script,Shader,VFX}
+        internal static string CreateAssetTypeFolders(string parentPath, string name)
+        {
+            var uniquePath = AssetDatabase.GenerateUniqueAssetPath(parentPath.CombinePath(name));
+            AssetDatabase.CreateFolder(parentPath, uniquePath.GetFilename(withExtension: true));
+
+            foreach (var subfolder in VzFoldersAssetTypeFolders.All)
+                CreateFolder(uniquePath, subfolder);
+
+            AssetDatabase.Refresh();
+            return uniquePath;
+        }
+
+        static void CreateFolder(string parentPath, string folderName)
+        {
+            var fullPath = parentPath.CombinePath(folderName);
+            if (!AssetDatabase.IsValidFolder(fullPath))
+                AssetDatabase.CreateFolder(parentPath, folderName);
+        }
+
+        class NewTypedFolderWizard : ScriptableWizard
+        {
+            public string folderName = "New Folder";
+            string parentPath;
+
+            public static void Show(string parentPath)
+            {
+                var wizard = DisplayWizard<NewTypedFolderWizard>("Create asset type folders", "Create", "Cancel");
+                wizard.parentPath = parentPath;
+            }
+
+            void OnWizardCreate()
+            {
+                if (string.IsNullOrWhiteSpace(folderName))
+                {
+                    Debug.LogWarning("VzFolders: introduce un nombre de carpeta válido.");
+                    return;
+                }
+
+                var createdPath = CreateAssetTypeFolders(parentPath, folderName);
+                Debug.Log($"VzFolders: carpetas de tipo de asset creadas en {createdPath}.");
+            }
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersProjectStructure.cs.meta
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersProjectStructure.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bb649ccd1358481b864c2fecbbb8b148

--- a/Packages/com.jaimecamachodev.unityfolders/package.json
+++ b/Packages/com.jaimecamachodev.unityfolders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jaimecamachodev.unityfolders",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "displayName": "VzFolders",
   "description": "VzFolders: navegador de carpetas personalizado para Unity con paletas de color e iconos por carpeta.",
   "unity": "6000.0",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Para instalarla en **otro proyecto de Unity**, añade un scoped registry a tu `P
     }
   ],
   "dependencies": {
-    "com.jaimecamachodev.unityfolders": "2.0.0"
+    "com.jaimecamachodev.unityfolders": "2.1.0"
   }
 }
 ```
@@ -54,13 +54,15 @@ También puedes hacerlo desde el Editor:
 ```
 Assets/
 │
-├── 1-Scripts/               → Scripts globales del proyecto (Managers, Systems, etc.)
+├── 1-Programming/           → Scripts globales, prefabs de lógica y materiales sólidos
+│   ├── Observers/
+│   ├── Prefabs/
+│   ├── Scripts/
+│   └── SolidMats/
 ├── 2-Art/                   → Todo el arte (3D, VFX, SFX, UI, etc.)
 ├── 3-Scenes/                → Escenas jugables (cargables)
 ├── 4-Presets/               → Presets de herramientas y assets
-├── 5-Settings/              → Settings del proyecto (URP, Inputs, Tags, etc.)
-├── Plugins/                 → Plugins externos o de la Asset Store
-└── Packages/                → Packages de Unity Package Manager (Read-only)
+└── 5-Settings/              → Settings del proyecto (URP, Inputs, Tags, etc.)
 ```
 
 ---
@@ -71,31 +73,35 @@ Assets/
 2-Art/
 │
 ├── 1-3D/                    → Modelos 3D organizados por tipo
-│   ├── Characters/          → Personajes (Player, NPCs, etc.)
-│   ├── Environment/         → Escenarios (por escena y globales)
-│   │   ├── Scene_1_Forest/  → Assets específicos de la escena 1
-│   │   └── Global/          → Assets comunes de entornos (Shared)
+│   ├── Animals/
+│   ├── Characters/
+│   └── Environments/
 │
 ├── 2-VFX/                   → Efectos visuales globales (fuego, explosiones, etc.)
 ├── 3-SFX/                   → Sonidos globales
 ├── 4-Directors/             → Timeline, Playables, cinemáticas
 ├── 5-Skyboxes/              → Cielos y entornos espaciales
 ├── 6-Videos/                → Videos y cutscenes
-├── 7-SolidMats/             → Materiales sólidos genéricos o tiles
-├── 8-PostProcessing/        → Post-Process assets y perfiles
-├── 9-UI/                    → Interfaces gráficas, fonts, prefabs de UI
-└── 10-Lighting/             → Lightmaps, HDRIs, configuraciones de iluminación
+├── 7-PostProcessing/        → Post-Process assets y perfiles
+└── 8-UI/                    → Interfaces gráficas, fonts, prefabs de UI
 ```
+
+Esta estructura se puede generar automáticamente con **VzFolders**: `Tools > JaimeCamachoDev > VzFolders > Project structure > Create base project structure` (o clic derecho en `Assets` > `VzFolders > Create base project structure`).
 
 ---
 
-## 📋 Reglas de Organización:
-1. **Cada escena** tiene su propia carpeta en `Environment` para sus assets internos.
-2. Assets que se usan en **múltiples escenas** van en las carpetas `Global` si corresponde.
-3. Los nombres de las escenas siguen el formato:  
-`Scene_01_NombrePropio` para orden automático y claridad.
-4. Scripts globales siempre van en `1-Scripts` (nunca mezclados con arte).
-5. Plugins y paquetes de terceros van en sus carpetas designadas (`Plugins` y `Packages`).
+## 🧹 Herramientas de organización de assets (VzFolders)
+
+Además de la navegación con paletas de color, VzFolders incluye un pipeline para que las carpetas de arte no se conviertan en un caos cuando varios artistas dejan texturas, mallas y prefabs mezclados. Todo vive bajo `Tools > JaimeCamachoDev > VzFolders > ...` y también como clic derecho en `Assets > VzFolders > ...`:
+
+- **Project structure > Create base project structure** — crea el árbol de carpetas de arriba.
+- **Project structure > Create asset type folders...** — pide un nombre y crea, dentro de la carpeta seleccionada, las subcarpetas por tipo: `Animation`, `Audio`, `Material`, `Mesh`, `Prefab`, `Script`, `Shader`, `VFX`.
+- **Organize > Organize this folder** — mueve, en el sitio, cada asset suelto de la carpeta seleccionada a su subcarpeta de tipo (creándolas si hace falta) y borra las subcarpetas que queden vacías.
+- **Organize > Organize into new subfolder...** — igual que lo anterior, pero primero envuelve todo el contenido en una subcarpeta nueva con el nombre que indiques.
+- **Organize > Rename assets with folder prefix** — renombra todos los assets de una carpeta con el prefijo del nombre de la carpeta (p. ej. `Rock01_Diffuse.png`).
+- **Ingest pipeline > Create materials (MAS / Lit)** — genera materiales URP a partir de texturas con sufijos `_ColorAlpha`, `_Normal`, `_MetalSmooth`/`_MaskMap`, `_AO`/`_Emission`, y los asigna automáticamente a los modelos importados de la misma carpeta.
+- **Ingest pipeline > Create prefabs from Mesh folder** — crea un prefab por cada malla dentro de la subcarpeta `Mesh`.
+- **Ingest pipeline > Full pipeline...** — asistente que encadena, de forma configurable, la creación de materiales, el volcado a una subcarpeta nueva, el renombrado y la creación de prefabs en un solo paso.
 
 ---
 


### PR DESCRIPTION
…lders, chaotic-folder sort, materials/prefabs)

Ports the functionality from the legacy UnityFolderOrganizer/UnityFoldersCreator/ UnityProjectStructureCreator/UnityMaterialsCreator/UnityPrefabCreator/UnityAssetsRenamer scripts (removed from the package in the previous rewrite) into the new VzFolders architecture, updated to the current folder taxonomy:

  1-Programming/{Observers,Prefabs,Scripts,SolidMats}
  2-Art/{1-3D/{Animals,Characters,Environments},2-VFX,3-SFX,4-Directors,
         5-Skyboxes,6-Videos,7-PostProcessing,8-UI}
  3-Scenes, 4-Presets, 5-Settings

New Editor/Pipeline module, wired into Tools/JaimeCamachoDev/VzFolders/... and the Assets/VzFolders/... context menu:
- VzFoldersProjectStructure: create the base tree above, or per-type asset folders (Animation/Audio/Material/Mesh/Prefab/Script/Shader/VFX) under a chosen name.
- VzFoldersOrganizer: sort a chaotic folder's loose files into that same per-type taxonomy in place, or after wrapping them in a new named subfolder.
- VzFoldersAssetsRenamer: prefix every asset in a folder with the folder name.
- VzFoldersMaterialsCreator: build URP materials from texture suffix conventions (MAS: _ColorAlpha/_Normal/_MetalSmooth/_AO, or Lit: _ColorAlpha/_Normal/_Emission/_MaskMap) and assign them to the folder's imported models.
- VzFoldersPrefabCreator: turn a Mesh folder's models into prefabs.
- VzFoldersIngestWizard: a single configurable wizard chaining the steps above, replacing the old duplicated MAS/LIT wizard variants.

VzFoldersAssetTypeFolders centralizes the extension-to-folder mapping (and folds the old organizer's "Sound" into "Audio" to match the folder creator) so folder creation and auto-sorting can never drift apart again.

Bump package.json to 2.1.0 and document the new tools in the README.


Claude-Session: https://claude.ai/code/session_018zFx38sd9jsi8HLejYKwC3