### PR TITLE
Fix VzFolders organizer silently doing nothing (StartAssetEditing bro…

### DIFF
--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersAssetsRenamer.cs
@@ -28,34 +28,27 @@ namespace VzFolders.Pipeline
 
         internal static void RenameAssetsInFolder(string folderPath)
         {
+            AssetDatabase.Refresh(); // import any file dropped in via the OS file explorer before AssetDatabase can see it
+
             var rootName = folderPath.GetFilename(withExtension: true);
             var guids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
 
-            try
+            foreach (var guid in guids)
             {
-                AssetDatabase.StartAssetEditing();
+                var assetPath = guid.ToPath();
+                if (AssetDatabase.IsValidFolder(assetPath)) continue;
 
-                foreach (var guid in guids)
-                {
-                    var assetPath = guid.ToPath();
-                    if (AssetDatabase.IsValidFolder(assetPath)) continue;
+                var directory = assetPath.GetParentPath();
+                var extension = assetPath.GetExtension();
+                var nameNoExt = assetPath.GetFilename(withExtension: false);
 
-                    var directory = assetPath.GetParentPath();
-                    var extension = assetPath.GetExtension();
-                    var nameNoExt = assetPath.GetFilename(withExtension: false);
+                if (nameNoExt == rootName || nameNoExt.StartsWith(rootName + "_")) continue;
 
-                    if (nameNoExt == rootName || nameNoExt.StartsWith(rootName + "_")) continue;
+                var underscoreIndex = nameNoExt.IndexOf('_');
+                var suffix = underscoreIndex >= 0 ? nameNoExt.Substring(underscoreIndex + 1) : nameNoExt;
 
-                    var underscoreIndex = nameNoExt.IndexOf('_');
-                    var suffix = underscoreIndex >= 0 ? nameNoExt.Substring(underscoreIndex + 1) : nameNoExt;
-
-                    var newPath = AssetDatabase.GenerateUniqueAssetPath(directory.CombinePath(rootName + "_" + suffix + extension));
-                    AssetDatabase.MoveAsset(assetPath, newPath);
-                }
-            }
-            finally
-            {
-                AssetDatabase.StopAssetEditing();
+                var newPath = AssetDatabase.GenerateUniqueAssetPath(directory.CombinePath(rootName + "_" + suffix + extension));
+                AssetDatabase.MoveAsset(assetPath, newPath);
             }
 
             AssetDatabase.Refresh();

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersMaterialsCreator.cs
@@ -49,6 +49,12 @@ namespace VzFolders.Pipeline
             };
 
             var textureSets = BuildTextureSets(folderPath, suffixes);
+            if (textureSets.Count == 0)
+            {
+                Debug.LogWarning($"VzFolders: no se encontró ninguna textura en {folderPath} con los sufijos _ColorAlpha/_Normal/_MetalSmooth/_AO — no se creó ningún material.");
+                return;
+            }
+
             CreateMaterialAssets(folderPath, textureSets, shader, CreateMasMaterialAsset);
             AssignMaterialsToModels(folderPath, textureSets, shader, CreateMasMaterialAsset);
 
@@ -72,6 +78,12 @@ namespace VzFolders.Pipeline
             };
 
             var textureSets = BuildTextureSets(folderPath, suffixes);
+            if (textureSets.Count == 0)
+            {
+                Debug.LogWarning($"VzFolders: no se encontró ninguna textura en {folderPath} con los sufijos _ColorAlpha/_Normal/_Emission/_MaskMap — no se creó ningún material.");
+                return;
+            }
+
             CreateMaterialAssets(folderPath, textureSets, shader, CreateLitMaterialAsset);
             AssignMaterialsToModels(folderPath, textureSets, shader, CreateLitMaterialAsset);
 
@@ -82,6 +94,8 @@ namespace VzFolders.Pipeline
 
         static Dictionary<string, TextureSet> BuildTextureSets(string folderPath, (string suffix, System.Action<TextureSet, Texture2D> assign)[] suffixes)
         {
+            AssetDatabase.Refresh(); // import any texture dropped in via the OS file explorer before AssetDatabase can see it
+
             var textureSets = new Dictionary<string, TextureSet>();
 
             foreach (var guid in AssetDatabase.FindAssets("t:Texture2D", new[] { folderPath }))

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersOrganizer.cs
@@ -51,32 +51,27 @@ namespace VzFolders.Pipeline
                 return null;
             }
 
+            // Import any file dropped in via the OS file explorer before AssetDatabase can see it.
+            AssetDatabase.Refresh();
+
             var newFolderPath = AssetDatabase.GenerateUniqueAssetPath(folderPath.CombinePath(newFolderName));
             AssetDatabase.CreateFolder(folderPath, newFolderPath.GetFilename(withExtension: true));
+            AssetDatabase.Refresh(); // the new folder must exist on disk before we generate paths into it below
 
-            try
+            foreach (var file in Directory.GetFiles(folderPath))
             {
-                AssetDatabase.StartAssetEditing();
-
-                foreach (var file in Directory.GetFiles(folderPath))
-                {
-                    if (file.EndsWith(".meta")) continue;
-                    var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(file)));
-                    AssetDatabase.MoveAsset(file.Replace("\\", "/"), destination);
-                }
-
-                foreach (var directory in Directory.GetDirectories(folderPath))
-                {
-                    var normalized = directory.Replace("\\", "/");
-                    if (normalized == newFolderPath) continue;
-
-                    var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(directory)));
-                    AssetDatabase.MoveAsset(normalized, destination);
-                }
+                if (file.EndsWith(".meta")) continue;
+                var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(file)));
+                AssetDatabase.MoveAsset(file.Replace("\\", "/"), destination);
             }
-            finally
+
+            foreach (var directory in Directory.GetDirectories(folderPath))
             {
-                AssetDatabase.StopAssetEditing();
+                var normalized = directory.Replace("\\", "/");
+                if (normalized == newFolderPath) continue;
+
+                var destination = AssetDatabase.GenerateUniqueAssetPath(newFolderPath.CombinePath(Path.GetFileName(directory)));
+                AssetDatabase.MoveAsset(normalized, destination);
             }
 
             AssetDatabase.Refresh();
@@ -88,35 +83,38 @@ namespace VzFolders.Pipeline
         // then deletes any subfolder left empty by the move.
         internal static void OrganizeFolder(string folderPath)
         {
-            try
-            {
-                AssetDatabase.StartAssetEditing();
+            // Import any file dropped in via the OS file explorer before AssetDatabase can see it.
+            AssetDatabase.Refresh();
 
-                var assetGuids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
-                foreach (var guid in assetGuids)
+            var movedCount = 0;
+            var assetGuids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
+            foreach (var guid in assetGuids)
+            {
+                var assetPath = guid.ToPath();
+                if (AssetDatabase.IsValidFolder(assetPath)) continue;
+
+                var destinationFolderName = VzFoldersAssetTypeFolders.GetFolderForAsset(assetPath);
+                if (destinationFolderName == null) continue;
+
+                var destinationFolder = folderPath.CombinePath(destinationFolderName);
+                if (!AssetDatabase.IsValidFolder(destinationFolder))
                 {
-                    var assetPath = guid.ToPath();
-                    if (AssetDatabase.IsValidFolder(assetPath)) continue;
-
-                    var destinationFolderName = VzFoldersAssetTypeFolders.GetFolderForAsset(assetPath);
-                    if (destinationFolderName == null) continue;
-
-                    var destinationFolder = folderPath.CombinePath(destinationFolderName);
-                    if (!AssetDatabase.IsValidFolder(destinationFolder))
-                        AssetDatabase.CreateFolder(folderPath, destinationFolderName);
-
-                    var destinationPath = AssetDatabase.GenerateUniqueAssetPath(destinationFolder.CombinePath(assetPath.GetFilename(withExtension: true)));
-                    AssetDatabase.MoveAsset(assetPath, destinationPath);
+                    AssetDatabase.CreateFolder(folderPath, destinationFolderName);
+                    AssetDatabase.Refresh(); // the new type folder must exist on disk before we generate a unique path into it below
                 }
-            }
-            finally
-            {
-                AssetDatabase.StopAssetEditing();
+
+                var destinationPath = AssetDatabase.GenerateUniqueAssetPath(destinationFolder.CombinePath(assetPath.GetFilename(withExtension: true)));
+                AssetDatabase.MoveAsset(assetPath, destinationPath);
+                movedCount++;
             }
 
             VzFoldersPipelineUtils.RemoveEmptySubdirectories(folderPath);
             AssetDatabase.Refresh();
-            Debug.Log($"VzFolders: carpeta {folderPath} ordenada.");
+
+            if (movedCount == 0)
+                Debug.LogWarning($"VzFolders: no había ningún asset suelto que ordenar en {folderPath} (¿ya estaban todos dentro de una subcarpeta?).");
+            else
+                Debug.Log($"VzFolders: carpeta {folderPath} ordenada ({movedCount} asset(s) movidos).");
         }
 
         class NewSubfolderWizard : ScriptableWizard

--- a/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs
+++ b/Packages/com.jaimecamachodev.unityfolders/Editor/Pipeline/VzFoldersPrefabCreator.cs
@@ -27,6 +27,8 @@ namespace VzFolders.Pipeline
 
         internal static void CreatePrefabsInFolder(string folderPath)
         {
+            AssetDatabase.Refresh(); // import any model dropped in via the OS file explorer before AssetDatabase can see it
+
             var meshFolder = folderPath.CombinePath(VzFoldersAssetTypeFolders.Mesh);
             var prefabFolder = folderPath.CombinePath(VzFoldersAssetTypeFolders.Prefab);
 
@@ -37,9 +39,19 @@ namespace VzFolders.Pipeline
             }
 
             if (!AssetDatabase.IsValidFolder(prefabFolder))
+            {
                 AssetDatabase.CreateFolder(folderPath, VzFoldersAssetTypeFolders.Prefab);
+                AssetDatabase.Refresh(); // the new Prefab folder must exist on disk before we generate a unique path into it below
+            }
 
-            foreach (var guid in AssetDatabase.FindAssets("t:Model", new[] { meshFolder }))
+            var modelGuids = AssetDatabase.FindAssets("t:Model", new[] { meshFolder });
+            if (modelGuids.Length == 0)
+            {
+                Debug.LogWarning($"VzFolders: no se encontró ninguna malla en {meshFolder} — no se creó ningún prefab.");
+                return;
+            }
+
+            foreach (var guid in modelGuids)
             {
                 var modelPath = guid.ToPath();
                 var model = AssetDatabase.LoadAssetAtPath<GameObject>(modelPath);


### PR DESCRIPTION
…ke folder-then-move)

AssetDatabase.StartAssetEditing() defers the on-disk creation of folders made with AssetDatabase.CreateFolder() until StopAssetEditing() runs. But GenerateUniqueAssetPath() checks the real filesystem, not the in-memory asset database, so when it was called (still inside the batch) against a type folder just created in the same batch, it returned "" — and MoveAsset with an empty destination silently no-ops. That's why "Organize this folder" appeared to do nothing and "Organize into new subfolder" only got as far as wrapping the loose files before its inner OrganizeFolder call went quiet.

Fix: drop the StartAssetEditing/StopAssetEditing batching (the old, proven-working scripts never used it either) and Refresh() right after creating a folder so subsequent GenerateUniqueAssetPath calls see it on disk. Also Refresh() up front in the organizer, renamer, materials creator and prefab creator so files just dropped in via the OS file explorer are picked up, and log a warning instead of silently doing nothing when there's nothing to move/no matching textures/no meshes to convert — so the next time something doesn't produce output, the Console says why.


Claude-Session: https://claude.ai/code/session_018zFx38sd9jsi8HLejYKwC3